### PR TITLE
feat: add github actions, codecov and lint configs

### DIFF
--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -1,0 +1,29 @@
+name: 'Setup Go Environment'
+description: 'Sets up Go environment'
+
+inputs:
+  go-version:
+    description: 'Go version to set up'
+    required: false
+    default: '1.24.2'
+  cache-dependency-path:
+    description: 'Path to go.sum for cache key generation'
+    required: false
+    default: '**/go.sum'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: ${{ inputs.go-version }}
+        cache-dependency-path: ${{ inputs.cache-dependency-path }}
+
+    - name: Download dependencies
+      shell: bash
+      run: go mod download
+
+    - name: Verify dependencies
+      shell: bash
+      run: go mod verify

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
       with:
         go-version: ${{ env.GO_VERSION }}
 
+    # TODO: Uncomment this once we have a fix golang lint config and fix all the issues
     # - name: Run golangci-lint
     #   uses: golangci/golangci-lint-action@v6
     #   with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,61 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  GO_VERSION: '1.24.2'
+
+jobs:
+  ci:
+    name: CI Pipeline
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Setup Go Environment
+      uses: ./.github/actions/setup-go
+      with:
+        go-version: ${{ env.GO_VERSION }}
+
+    # - name: Run golangci-lint
+    #   uses: golangci/golangci-lint-action@v6
+    #   with:
+    #     version: latest
+    #     args: --timeout=5m
+
+    - name: Run vet
+      run: go vet ./...
+
+    - name: Run tests
+      run: go test -v -race -coverprofile=coverage.out ./...
+
+    - name: Generate coverage report
+      run: go tool cover -html=coverage.out -o coverage.html
+
+    - name: Upload coverage reports to Codecov
+      uses: codecov/codecov-action@v4
+      with:
+        file: ./coverage.out
+        flags: unittests
+        name: codecov-umbrella
+        fail_ci_if_error: false
+
+    - name: Build main packages
+      run: go build -v ./...
+
+    - name: Build examples
+      run: |
+        for example in examples/*/; do
+          if [ -f "$example/main.go" ]; then
+            echo "Building $example"
+            cd "$example"
+            go build -v .
+            cd - > /dev/null
+          fi
+        done

--- a/.gitignore
+++ b/.gitignore
@@ -28,5 +28,5 @@ go.work.sum
 .env
 
 # Editor/IDE
-# .idea/
-# .vscode/
+.idea/
+.vscode/

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,17 +1,15 @@
 run:
   timeout: 5m
 
+version: 2
+
 linters:
   enable:
-    - gofmt
-    - goimports
     - govet
     - errcheck
     - staticcheck
     - unused
-    - gosimple
     - ineffassign
-    - typecheck
     - revive
     - gocyclo
     - nestif
@@ -19,6 +17,8 @@ linters:
     - unparam
     - nilerr
     - prealloc
+    - goconst
+    - gocritic
 
 issues:
   exclude-use-default: false

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,33 @@
+run:
+  timeout: 5m
+
+linters:
+  enable:
+    - gofmt
+    - goimports
+    - govet
+    - errcheck
+    - staticcheck
+    - unused
+    - gosimple
+    - ineffassign
+    - typecheck
+    - revive
+    - gocyclo
+    - nestif
+    - misspell
+    - unparam
+    - nilerr
+    - prealloc
+
+issues:
+  exclude-use-default: false
+  exclude-rules:
+    - path: _test\.go
+      linters:
+        - errcheck
+    - path: examples/
+      linters:
+        - errcheck
+  max-issues-per-linter: 0
+  max-same-issues: 0

--- a/README.md
+++ b/README.md
@@ -2,11 +2,6 @@
 
 <img src=".github/images/go-calque.webp" alt="Go-Calque" width="350">
 
-[![CI](https://github.com/calque-ai/go-calque/actions/workflows/ci.yml/badge.svg)](https://github.com/calque-ai/go-calque/actions/workflows/ci.yml)
-[![codecov](https://codecov.io/gh/calque-ai/go-calque/branch/main/graph/badge.svg)](https://codecov.io/gh/calque-ai/go-calque)
-[![Go Report Card](https://goreportcard.com/badge/github.com/calque-ai/go-calque)](https://goreportcard.com/report/github.com/calque-ai/go-calque)
-[![Go Reference](https://pkg.go.dev/badge/github.com/calque-ai/go-calque.svg)](https://pkg.go.dev/github.com/calque-ai/go-calque)
-
 An idiomatic streaming **multi-agent AI framework** for Go.
 
 _Developed by [Calque AI](https://calque.ai)_

--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 <img src=".github/images/go-calque.webp" alt="Go-Calque" width="350">
 
+[![CI](https://github.com/calque-ai/go-calque/actions/workflows/ci.yml/badge.svg)](https://github.com/calque-ai/go-calque/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/calque-ai/go-calque/branch/main/graph/badge.svg)](https://codecov.io/gh/calque-ai/go-calque)
+[![Go Report Card](https://goreportcard.com/badge/github.com/calque-ai/go-calque)](https://goreportcard.com/report/github.com/calque-ai/go-calque)
+[![Go Reference](https://pkg.go.dev/badge/github.com/calque-ai/go-calque.svg)](https://pkg.go.dev/github.com/calque-ai/go-calque)
+
 An idiomatic streaming **multi-agent AI framework** for Go.
 
 _Developed by [Calque AI](https://calque.ai)_


### PR DESCRIPTION
I don’t have permission to trigger workflows on the upstream repo, so I opened this PR from my fork.
You can see the workflow run here: [GitHub Actions run link](https://github.com/ankittk/go-calque/actions/runs/17111565177/job/48533958478?pr=1)

Please take a look at the current golangci-lint configuration, there are a few issues with it that we should fix in a separate PR after this one is merged. Once that’s done, we can safely uncomment the golangci-lint step in the workflow.

- the 2nd commit is to fix a test which caught while running the workflows