### PR TITLE
feat: add implement openai client in middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,8 +94,9 @@ flowchart TB
         N(["Buffered<br>Read all data first<br>for complex processing"])
     end
     subgraph subGraph3["LLM Providers"]
-        O["Ollama"]
-        P["Gemini"]
+        O["OpenAI"]
+        P["Ollama"]
+        Q["Gemini"]
     end
     A["User Application"] --> B["Calque Flow"]
     B --> C
@@ -103,7 +104,7 @@ flowchart TB
     D -- "io.Pipe" --> E
     E -- "io.Pipe" --> F
     F --> G
-    E --> H & O & P
+    E --> H & O & P & Q
     H -- Yes --> I
     H -- No --> J
     I --> K
@@ -129,6 +130,7 @@ flowchart TB
     N:::modes
     O:::llmProvider
     P:::llmProvider
+    Q:::llmProvider
 
 %% Dark Mode Styles
     classDef inputOutput fill:#1e293b,stroke:#93c5fd,stroke-width:2px,color:#f9fafb
@@ -154,8 +156,8 @@ flowchart TB
 
 🤖 **AI Agent Processing**: Intelligent decision-making for tool calling vs direct chat, with response synthesis
 
-🌐 **LLM Provider Layer**:
-
+🌐 **LLM Provider Layer**: 
+- **OpenAI** ⚡ Leading AI API (GPT-4, GPT-3.5, advanced capabilities)
 - **Ollama** 🏠 Local server (privacy, no API costs)
 - **Gemini** ☁️ Google Cloud API (advanced capabilities)
 
@@ -167,7 +169,7 @@ Go-Calque includes middleware for common AI and data processing patterns:
 
 ### AI & LLM (`ai/`, `prompt/`)
 
-- **AI Agents**: `ai.Agent(client)` - Connect to Gemini, Ollama, or custom providers
+- **AI Agents**: `ai.Agent(client)` - Connect to OpenAI, Gemini, Ollama, or custom providers
 - **Prompt Templates**: `prompt.Template("Question: {{.Input}}")` - Dynamic prompt formatting
 - **Streaming Support**: Real-time response processing as tokens arrive
 
@@ -257,6 +259,7 @@ flow.Run(ctx, "hello", &result)
 ### AI Chat with Memory
 
 ```go
+// with ollama
 client, _ := ollama.New("llama3.2:1b")
 convMem := memory.NewConversation()
 
@@ -265,6 +268,20 @@ flow := calque.NewFlow().
     Use(prompt.Template("User: {{.Input}}\nAssistant:")).
     Use(ai.Agent(client)).
     Use(convMem.Output("user123")) //store ai response
+
+var response string
+flow.Run(ctx, "What's the capital of France?", &response)
+```
+
+```go
+// With OpenAI
+client, _ := openai.New("gpt-5")
+convMem := memory.NewConversation()
+
+flow := calque.NewFlow().
+    Use(convMem.Input("user123")).
+    Use(ai.Agent(client)).
+    Use(convMem.Output("user123"))
 
 var response string
 flow.Run(ctx, "What's the capital of France?", &response)

--- a/examples/ai-clients/README.md
+++ b/examples/ai-clients/README.md
@@ -22,9 +22,20 @@ This directory demonstrates how to connect different AI providers to Calque-Pipe
   - Temperature control and model parameters
   - Prompt templating with `prompt.Template()`
 
+### OpenAI Integration (`openaiExample`)
+
+- **Cloud AI Provider**: OpenAI's GPT models integration
+- **Features Covered**:
+  - Creating OpenAI clients with `openai.New()`
+  - Custom configuration with `openai.Config`
+  - Model specification (e.g., `gpt-5`, `gpt-4`)
+  - Temperature and token control
+  - Timeout protection with `ctrl.Timeout()`
+  - Prompt templating with `prompt.Template()`
+
 ## Key AI Integration Concepts
 
-- **Provider Abstraction**: Both local (Ollama) and cloud (Gemini) providers use the same `ai.Client` interface
+- **Provider Abstraction**: Local (Ollama) and cloud (Gemini, OpenAI) providers use the same `ai.Client` interface
 - **Configuration Flexibility**: Each provider supports custom configuration options for fine-tuning behavior
 - **Timeout Management**: AI calls can be wrapped with timeouts to prevent hanging pipelines
 - **Prompt Engineering**: Different approaches for preparing input (direct transformation vs. template-based)
@@ -51,12 +62,19 @@ go run main.go
 - Create `.env` file with: `GOOGLE_API_KEY=your_api_key`
 - Ensure internet connectivity for API calls
 
+#### For OpenAI Example
+
+- Get API key from [OpenAI Platform](https://platform.openai.com/api-keys)
+- Create `.env` file with: `OPENAI_API_KEY=your_api_key`
+- Ensure internet connectivity for API calls
+
 ## Example Output
 
 The examples demonstrate AI provider integration:
 
 - **Ollama**: Local model execution with input transformation and timeout protection
 - **Gemini**: Cloud API calls with custom configuration and prompt templating
+- **OpenAI**: Cloud API calls with GPT models, configuration options, and timeout management
 
 Both examples show:
 

--- a/examples/ai-clients/main.go
+++ b/examples/ai-clients/main.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"os"
 	"time"
 
 	"github.com/joho/godotenv"
@@ -15,6 +16,7 @@ import (
 	"github.com/calque-ai/go-calque/pkg/middleware/ai"
 	"github.com/calque-ai/go-calque/pkg/middleware/ai/gemini"
 	"github.com/calque-ai/go-calque/pkg/middleware/ai/ollama"
+	"github.com/calque-ai/go-calque/pkg/middleware/ai/openai"
 	"github.com/calque-ai/go-calque/pkg/middleware/ctrl"
 	"github.com/calque-ai/go-calque/pkg/middleware/logger"
 	"github.com/calque-ai/go-calque/pkg/middleware/prompt"
@@ -25,6 +27,7 @@ func main() {
 
 	ollamaExample()
 	geminiExample()
+	openaiExample()
 }
 
 func ollamaExample() {
@@ -87,6 +90,57 @@ func geminiExample() {
 		Use(logger.Print("PROMPT")).                                                     // Log the finalized prompt
 		Use(ai.Agent(client)).                                                           // Send prompt to llm agent
 		Use(logger.Head("RESPONSE", 200))                                                // Log the agent response using logger.head for streaming
+
+	// Run the flow
+	var result string
+	err = flow.Run(context.Background(), "What is the Go programming language?", &result)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Println("\nFinal result:")
+	fmt.Println(result)
+}
+
+func openaiExample() {
+
+	// Load environment variables from .env file
+	// Make sure to have OPENAI_API_KEY set in your .env file
+	err := godotenv.Load(".env")
+	if err != nil {
+		log.Printf("Warning: Could not load .env file: %v", err)
+		log.Println("To run OpenAI example:")
+		log.Println("  1. Get API key from: https://platform.openai.com/api-keys")
+		log.Println("  2. Create .env file with: OPENAI_API_KEY=your_api_key")
+		return
+	}
+
+	// Create an optional custom OpenAI configuration
+	config := &openai.Config{
+		APIKey:              os.Getenv("OPENAI_API_KEY"), // Optionally set API key here instead of env var
+		Temperature:         ai.Float32Ptr(0.8),
+		MaxCompletionTokens: ai.IntPtr(150),
+	}
+
+	// Create OpenAI client (reads OPENAI_API_KEY from env unless set in the config)
+	client, err := openai.New("gpt-5", openai.WithConfig(config))
+	if err != nil {
+		log.Printf("Warning: Could not connect to OpenAI: %v", err)
+		log.Println("To run OpenAI example:")
+		log.Println("  1. Get API key from: https://platform.openai.com/api-keys")
+		log.Println("  2. Set: export OPENAI_API_KEY=your_api_key")
+		return
+	}
+
+	// Create flow with LLM integration
+	flow := calque.NewFlow()
+
+	flow.
+		Use(logger.Print("INPUT")).                                                      // Log input
+		Use(prompt.Template("Please provide a concise response. Question: {{.Input}}")). // Setup a prompt template
+		Use(logger.Print("PROMPT")).                                                     // Log the finalized prompt
+		Use(ctrl.Timeout(ai.Agent(client), 30*time.Second)).                             // Send prompt to LLM agent with timeout
+		Use(logger.Head("RESPONSE", 200))                                                // Log the agent response
 
 	// Run the flow
 	var result string

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/joho/godotenv v1.5.1
 	github.com/ollama/ollama v0.11.4
 	github.com/rs/zerolog v1.34.0
+	github.com/sashabaranov/go-openai v1.41.1
 	github.com/wk8/go-ordered-map/v2 v2.1.8
 	google.golang.org/genai v1.19.0
 )

--- a/go.sum
+++ b/go.sum
@@ -76,6 +76,8 @@ github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWN
 github.com/rs/xid v1.6.0/go.mod h1:7XoLgs4eV+QndskICGsho+ADou8ySMSjJKDIan90Nz0=
 github.com/rs/zerolog v1.34.0 h1:k43nTLIwcTVQAncfCw4KZ2VY6ukYoZaBPNOE8txlOeY=
 github.com/rs/zerolog v1.34.0/go.mod h1:bJsvje4Z08ROH4Nhs5iH600c3IkWhwp44iRc54W6wYQ=
+github.com/sashabaranov/go-openai v1.41.1 h1:zf5tM+GuxpyiyD9XZg8nCqu52eYFQg9OOew0gnIuDy4=
+github.com/sashabaranov/go-openai v1.41.1/go.mod h1:lj5b/K+zjTSFxVLijLSTDZuP7adOgerWeFyZLUhAKRg=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/wk8/go-ordered-map/v2 v2.1.8 h1:5h/BUHu93oj4gIdvHHHGsScSTMijfx5PeYkE/fJgbpc=

--- a/pkg/middleware/ai/openai/openai.go
+++ b/pkg/middleware/ai/openai/openai.go
@@ -1,0 +1,614 @@
+// Package openai provides OpenAI API client middleware for the Calque framework.
+// It supports streaming chat completions, tool calling, and multimodal capabilities
+// with GPT-5, GPT-4, GPT-3.5, and other OpenAI models.
+package openai
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/sashabaranov/go-openai"
+
+	"github.com/calque-ai/go-calque/pkg/calque"
+	"github.com/calque-ai/go-calque/pkg/middleware/ai"
+	"github.com/calque-ai/go-calque/pkg/middleware/tools"
+)
+
+// Client implements the Client interface for OpenAI.
+//
+// Provides streaming chat completions with tool calling and multimodal support.
+// Supports GPT-5, GPT-4, GPT-4o, GPT-4o-mini, GPT-3.5, and other OpenAI models with full feature compatibility.
+//
+// Example:
+//
+//	client, _ := openai.New("gpt-5")
+//	agent := ai.Agent(client)
+type Client struct {
+	client *openai.Client
+	model  string
+	config *Config
+}
+
+// Config holds OpenAI-specific configuration.
+//
+// Configures model behavior, API settings, and response format.
+// All fields are optional with sensible defaults.
+//
+// Example:
+//
+//	config := &openai.Config{
+//		APIKey: "sk-...",
+//		Temperature: ai.Float32Ptr(0.8),
+//		MaxTokens: ai.IntPtr(1000),
+//	}
+type Config struct {
+	// Required. API key for OpenAI authentication
+	APIKey string
+
+	// Optional. Base URL for OpenAI API (defaults to official OpenAI API)
+	BaseURL string
+
+	// Optional. Organization ID for OpenAI API requests
+	OrgID string
+
+	// Optional. Controls randomness in token selection (0.0-2.0)
+	// Lower values = more deterministic, higher values = more creative
+	Temperature *float32
+
+	// Optional. Nucleus sampling parameter (0.0-1.0)
+	// Tokens are selected until their probabilities sum to this value
+	TopP *float32
+
+	// Optional. Maximum number of completion tokens
+	MaxCompletionTokens *int
+
+	// Optional. Number of chat completion choices to generate
+	N *int
+
+	// Optional. Strings that stop text generation when encountered
+	Stop []string
+
+	// Optional. Penalize tokens that already appear in generated text (-2.0 to 2.0)
+	// Positive values increase content diversity
+	PresencePenalty *float32
+
+	// Optional. Penalize frequently repeated tokens (-2.0 to 2.0)
+	// Positive values reduce repetition
+	FrequencyPenalty *float32
+
+	// Optional. User ID for tracking and abuse monitoring
+	User string
+
+	// Optional. Fixed seed for reproducible responses (GPT-4 and newer)
+	Seed *int
+
+	// Optional. Response format configuration (JSON schema, etc.)
+	ResponseFormat *ai.ResponseFormat
+
+	// Optional. Enable/disable streaming of responses (true by default)
+	Stream *bool
+}
+
+// Option interface for functional options pattern
+type Option interface {
+	Apply(*Config)
+}
+
+// configOption implements Option
+type configOption struct {
+	config *Config
+}
+
+func (o configOption) Apply(opts *Config) {
+	*opts = *o.config
+}
+
+// WithConfig sets custom OpenAI configuration.
+//
+// Input: *Config with OpenAI settings
+// Output: Option for client creation
+// Behavior: Overrides default configuration
+//
+// Example:
+//
+//	config := &openai.Config{Temperature: ai.Float32Ptr(0.9)}
+//	client, _ := openai.New("gpt-4", openai.WithConfig(config))
+func WithConfig(config *Config) Option {
+	return configOption{config: config}
+}
+
+// DefaultConfig returns sensible defaults for OpenAI.
+//
+// Input: none
+// Output: *Config with default settings
+// Behavior: Creates config with OPENAI_API_KEY from env
+//
+// Sets temperature to 0.7 and API key from environment.
+//
+// Example:
+//
+//	config := openai.DefaultConfig()
+//	config.MaxTokens = ai.IntPtr(2000)
+func DefaultConfig() *Config {
+	return &Config{
+		APIKey:      os.Getenv("OPENAI_API_KEY"),
+		Temperature: ai.Float32Ptr(0.7),
+		Stream:      ai.BoolPtr(true),
+	}
+}
+
+// New creates a new OpenAI client with optional configuration.
+//
+// Input: model name string, optional config Options
+// Output: *Client, error
+// Behavior: Initializes authenticated OpenAI client
+//
+// Requires OPENAI_API_KEY environment variable or config.APIKey.
+// Supports all OpenAI models: gpt-4, gpt-3.5-turbo, etc.
+//
+// Example:
+//
+//	client, err := openai.New("gpt-4")
+//	if err != nil { log.Fatal(err) }
+func New(model string, opts ...Option) (*Client, error) {
+	if model == "" {
+		return nil, fmt.Errorf("model name is required")
+	}
+
+	// Build config from options
+	config := DefaultConfig()
+	for _, opt := range opts {
+		opt.Apply(config)
+	}
+
+	// Validate API key
+	if config.APIKey == "" {
+		return nil, fmt.Errorf("OPENAI_API_KEY environment variable not set or provided in config")
+	}
+
+	// Create OpenAI client configuration
+	clientConfig := openai.DefaultConfig(config.APIKey)
+	if config.BaseURL != "" {
+		clientConfig.BaseURL = config.BaseURL
+	}
+	if config.OrgID != "" {
+		clientConfig.OrgID = config.OrgID
+	}
+
+	client := openai.NewClientWithConfig(clientConfig)
+
+	return &Client{
+		client: client,
+		model:  model,
+		config: config,
+	}, nil
+}
+
+// RequestConfig holds configuration for an OpenAI request
+type RequestConfig struct {
+	ChatRequest openai.ChatCompletionRequest
+}
+
+// Chat implements the Client interface with streaming support.
+//
+// Input: user prompt/query via calque.Request
+// Output: streamed AI response via calque.Response
+// Behavior: STREAMING - outputs tokens as they arrive
+//
+// Supports tool calling, JSON schema responses, and multimodal content.
+// Automatically formats tool calls for agent framework compatibility.
+//
+// Example:
+//
+//	err := client.Chat(req, res, &ai.AgentOptions{Tools: tools})
+func (c *Client) Chat(r *calque.Request, w *calque.Response, opts *ai.AgentOptions) error {
+	// Which input type are we processing?
+	input, err := ai.ClassifyInput(r, opts)
+	if err != nil {
+		return err
+	}
+
+	// Build request configuration based on input type
+	config, err := c.buildRequestConfig(input, ai.GetSchema(opts), ai.GetTools(opts))
+	if err != nil {
+		return err
+	}
+
+	// Execute the request with the configured chat
+	return c.executeRequest(config, r, w)
+}
+
+// buildRequestConfig creates configuration for the request
+func (c *Client) buildRequestConfig(input *ai.ClassifiedInput, schema *ai.ResponseFormat, tools []tools.Tool) (*RequestConfig, error) {
+	// Create base chat request
+	req := openai.ChatCompletionRequest{
+		Model: c.model,
+	}
+
+	// Convert input to messages
+	messages, err := c.inputToMessages(input)
+	if err != nil {
+		return nil, err
+	}
+	req.Messages = messages
+
+	// Apply configuration
+	c.applyChatConfig(&req, schema)
+
+	// Add tools if provided
+	if len(tools) > 0 {
+		req.Tools = c.convertToOpenAITools(tools)
+		req.ToolChoice = "auto"
+	}
+
+	return &RequestConfig{
+		ChatRequest: req,
+	}, nil
+}
+
+// executeRequest executes the configured request
+func (c *Client) executeRequest(config *RequestConfig, r *calque.Request, w *calque.Response) error {
+	// Determine if we should stream
+	shouldStream := c.config.Stream == nil || *c.config.Stream
+
+	if shouldStream {
+		return c.executeStreamingRequest(config, r, w)
+	}
+	return c.executeNonStreamingRequest(config, r, w)
+}
+
+// executeStreamingRequest executes a streaming request
+func (c *Client) executeStreamingRequest(config *RequestConfig, r *calque.Request, w *calque.Response) error {
+	// Enable streaming
+	config.ChatRequest.Stream = true
+
+	// Create streaming request
+	stream, err := c.client.CreateChatCompletionStream(r.Context, config.ChatRequest)
+	if err != nil {
+		return fmt.Errorf("failed to create chat completion stream: %w", err)
+	}
+	defer func() {
+		if closeErr := stream.Close(); closeErr != nil {
+			// Log the error but don't return it as it's in a defer
+			fmt.Printf("warning: failed to close stream: %v\n", closeErr)
+		}
+	}()
+
+	var toolCalls []openai.ToolCall
+	var functionCallName, functionCallArgs string
+
+	// Process streaming response
+	if err := c.processStreamingResponse(stream, w, &functionCallName, &functionCallArgs); err != nil {
+		return err
+	}
+
+	// If we accumulated a complete tool call, format it
+	if functionCallName != "" {
+		toolCall := openai.ToolCall{
+			Type: "function",
+			Function: openai.FunctionCall{
+				Name:      functionCallName,
+				Arguments: functionCallArgs,
+			},
+		}
+		toolCalls = append(toolCalls, toolCall)
+	}
+
+	// Format tool calls if we have any
+	if len(toolCalls) > 0 {
+		return c.writeOpenAIToolCalls(toolCalls, w)
+	}
+
+	return nil
+}
+
+// processStreamingResponse handles the streaming response processing
+func (c *Client) processStreamingResponse(stream *openai.ChatCompletionStream, w *calque.Response, functionCallName, functionCallArgs *string) error {
+	for {
+		response, err := stream.Recv()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return fmt.Errorf("failed to receive stream response: %w", err)
+		}
+
+		if len(response.Choices) > 0 {
+			if err := c.processStreamingDelta(response.Choices[0].Delta, w, functionCallName, functionCallArgs); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// processStreamingDelta processes a single streaming delta response
+func (c *Client) processStreamingDelta(delta openai.ChatCompletionStreamChoiceDelta, w *calque.Response, functionCallName, functionCallArgs *string) error {
+	// Handle content streaming
+	if delta.Content != "" {
+		if _, writeErr := w.Data.Write([]byte(delta.Content)); writeErr != nil {
+			return writeErr
+		}
+	}
+
+	// Handle tool calls (streaming)
+	if len(delta.ToolCalls) > 0 {
+		for _, toolCall := range delta.ToolCalls {
+			if toolCall.Function.Name != "" {
+				*functionCallName = toolCall.Function.Name
+				*functionCallArgs = ""
+			}
+			if toolCall.Function.Arguments != "" {
+				*functionCallArgs += toolCall.Function.Arguments
+			}
+		}
+	}
+
+	return nil
+}
+
+// executeNonStreamingRequest executes a non-streaming request
+func (c *Client) executeNonStreamingRequest(config *RequestConfig, r *calque.Request, w *calque.Response) error {
+	// Disable streaming
+	config.ChatRequest.Stream = false
+
+	// Create request
+	response, err := c.client.CreateChatCompletion(r.Context, config.ChatRequest)
+	if err != nil {
+		return fmt.Errorf("failed to create chat completion: %w", err)
+	}
+
+	if len(response.Choices) == 0 {
+		return fmt.Errorf("no response choices returned")
+	}
+
+	choice := response.Choices[0]
+
+	// Handle tool calls
+	if len(choice.Message.ToolCalls) > 0 {
+		return c.writeOpenAIToolCalls(choice.Message.ToolCalls, w)
+	}
+
+	// Handle content
+	if choice.Message.Content != "" {
+		_, err := w.Data.Write([]byte(choice.Message.Content))
+		return err
+	}
+
+	return nil
+}
+
+// inputToMessages converts classified input to OpenAI message format
+func (c *Client) inputToMessages(input *ai.ClassifiedInput) ([]openai.ChatCompletionMessage, error) {
+	switch input.Type {
+	case ai.TextInput:
+		return []openai.ChatCompletionMessage{
+			{
+				Role:    openai.ChatMessageRoleUser,
+				Content: input.Text,
+			},
+		}, nil
+
+	case ai.MultimodalJSONInput, ai.MultimodalStreamingInput:
+		return c.multimodalToMessages(input.Multimodal)
+
+	default:
+		return nil, fmt.Errorf("unsupported input type: %d", input.Type)
+	}
+}
+
+// multimodalToMessages converts multimodal input to OpenAI message format
+func (c *Client) multimodalToMessages(multimodal *ai.MultimodalInput) ([]openai.ChatCompletionMessage, error) {
+	if multimodal == nil {
+		return nil, fmt.Errorf("multimodal input cannot be nil")
+	}
+
+	var messageParts []openai.ChatMessagePart
+
+	for _, part := range multimodal.Parts {
+		switch part.Type {
+		case "text":
+			if part.Text != "" {
+				messageParts = append(messageParts, openai.ChatMessagePart{
+					Type: openai.ChatMessagePartTypeText,
+					Text: part.Text,
+				})
+			}
+		case "image":
+			var data []byte
+			var err error
+
+			if part.Reader != nil {
+				// Read stream data (streaming approach)
+				data, err = io.ReadAll(part.Reader)
+				if err != nil {
+					return nil, fmt.Errorf("failed to read image data: %w", err)
+				}
+			} else if part.Data != nil {
+				// Use embedded data (simple approach)
+				data = part.Data
+			}
+
+			if data != nil {
+				// Convert to base64 data URL
+				dataURL := fmt.Sprintf("data:%s;base64,%s", part.MimeType, string(data))
+				messageParts = append(messageParts, openai.ChatMessagePart{
+					Type: openai.ChatMessagePartTypeImageURL,
+					ImageURL: &openai.ChatMessageImageURL{
+						URL: dataURL,
+					},
+				})
+			}
+		case "audio", "video":
+			// OpenAI doesn't support audio/video in chat completions yet
+			return nil, fmt.Errorf("audio and video content not yet supported by OpenAI Chat Completions API")
+		default:
+			return nil, fmt.Errorf("unsupported content part type: %s", part.Type)
+		}
+	}
+
+	if len(messageParts) == 0 {
+		return nil, fmt.Errorf("no valid content parts found in multimodal input")
+	}
+
+	return []openai.ChatCompletionMessage{
+		{
+			Role:         openai.ChatMessageRoleUser,
+			MultiContent: messageParts,
+		},
+	}, nil
+}
+
+// applyChatConfig applies client configuration to the chat request
+func (c *Client) applyChatConfig(req *openai.ChatCompletionRequest, schema *ai.ResponseFormat) {
+	// Check if this is a GPT-5 model (has beta limitations)
+	isGPT5 := c.isGPT5Model()
+
+	// Apply client configuration
+	if c.config.Temperature != nil && !isGPT5 {
+		req.Temperature = *c.config.Temperature
+	}
+	if c.config.TopP != nil && !isGPT5 {
+		req.TopP = *c.config.TopP
+	}
+
+	// Handle token limits - use MaxCompletionTokens for all models
+	if c.config.MaxCompletionTokens != nil {
+		req.MaxCompletionTokens = *c.config.MaxCompletionTokens
+	}
+
+	if c.config.N != nil && !isGPT5 {
+		req.N = *c.config.N
+	}
+	if len(c.config.Stop) > 0 {
+		req.Stop = c.config.Stop
+	}
+	if c.config.PresencePenalty != nil && !isGPT5 {
+		req.PresencePenalty = *c.config.PresencePenalty
+	}
+	if c.config.FrequencyPenalty != nil && !isGPT5 {
+		req.FrequencyPenalty = *c.config.FrequencyPenalty
+	}
+	if c.config.User != "" {
+		req.User = c.config.User
+	}
+	if c.config.Seed != nil {
+		req.Seed = c.config.Seed
+	}
+
+	// Apply response format - request override takes priority
+	var responseFormat *ai.ResponseFormat
+	if schema != nil {
+		responseFormat = schema
+	} else {
+		responseFormat = c.config.ResponseFormat
+	}
+
+	if responseFormat != nil {
+		req.ResponseFormat = c.buildResponseFormat(responseFormat)
+	}
+}
+
+// buildResponseFormat creates the OpenAI response format configuration
+func (c *Client) buildResponseFormat(responseFormat *ai.ResponseFormat) *openai.ChatCompletionResponseFormat {
+	switch responseFormat.Type {
+	case "json_object":
+		return &openai.ChatCompletionResponseFormat{
+			Type: openai.ChatCompletionResponseFormatTypeJSONObject,
+		}
+	case "json_schema":
+		if responseFormat.Schema != nil {
+			// Convert jsonschema.Schema to OpenAI format
+			schemaBytes, err := json.Marshal(responseFormat.Schema)
+			if err == nil {
+				var schemaObj interface{}
+				if json.Unmarshal(schemaBytes, &schemaObj) == nil {
+					return &openai.ChatCompletionResponseFormat{
+						Type: openai.ChatCompletionResponseFormatTypeJSONSchema,
+						JSONSchema: &openai.ChatCompletionResponseFormatJSONSchema{
+							Name:   "response_schema",
+							Schema: json.RawMessage(schemaBytes),
+							Strict: true,
+						},
+					}
+				}
+			}
+		}
+		// Fallback to json_object if schema is nil or invalid
+		return &openai.ChatCompletionResponseFormat{
+			Type: openai.ChatCompletionResponseFormatTypeJSONObject,
+		}
+	default:
+		return nil
+	}
+}
+
+// isGPT5Model checks if the current model is a GPT-5 variant
+func (c *Client) isGPT5Model() bool {
+	return c.model == "gpt-5" || c.model == "gpt-5o" || c.model == "gpt-5o-mini"
+}
+
+// convertToOpenAITools converts our tool interface to OpenAI's tool format
+func (c *Client) convertToOpenAITools(toolList []tools.Tool) []openai.Tool {
+	openaiTools := make([]openai.Tool, 0, len(toolList))
+
+	for _, tool := range toolList {
+		schema := tool.ParametersSchema()
+
+		// Convert schema to OpenAI format - schema is already in OpenAI format
+		var parameters map[string]interface{}
+		if schema != nil {
+			// Marshal and unmarshal to convert to generic map
+			if schemaBytes, err := json.Marshal(schema); err == nil {
+				if unmarshalErr := json.Unmarshal(schemaBytes, &parameters); unmarshalErr != nil {
+					// Log the error but continue with empty parameters
+					fmt.Printf("warning: failed to unmarshal schema: %v\n", unmarshalErr)
+				}
+			}
+		}
+
+		openaiTool := openai.Tool{
+			Type: openai.ToolTypeFunction,
+			Function: &openai.FunctionDefinition{
+				Name:        tool.Name(),
+				Description: tool.Description(),
+				Parameters:  parameters,
+			},
+		}
+		openaiTools = append(openaiTools, openaiTool)
+	}
+
+	return openaiTools
+}
+
+// writeOpenAIToolCalls formats OpenAI tool calls for the agent framework
+func (c *Client) writeOpenAIToolCalls(toolCalls []openai.ToolCall, w *calque.Response) error {
+	// Convert to the expected format
+	formattedToolCalls := make([]map[string]any, 0, len(toolCalls))
+
+	for _, call := range toolCalls {
+		toolCall := map[string]any{
+			"type": "function",
+			"function": map[string]any{
+				"name":      call.Function.Name,
+				"arguments": call.Function.Arguments,
+			},
+		}
+		formattedToolCalls = append(formattedToolCalls, toolCall)
+	}
+
+	// Create the expected JSON structure
+	result := map[string]any{
+		"tool_calls": formattedToolCalls,
+	}
+
+	jsonBytes, err := json.Marshal(result)
+	if err != nil {
+		return err
+	}
+
+	_, err = w.Data.Write(jsonBytes)
+	return err
+}

--- a/pkg/middleware/ai/openai/openai_test.go
+++ b/pkg/middleware/ai/openai/openai_test.go
@@ -1,0 +1,1134 @@
+package openai
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/invopop/jsonschema"
+	"github.com/sashabaranov/go-openai"
+	orderedmap "github.com/wk8/go-ordered-map/v2"
+
+	"github.com/calque-ai/go-calque/pkg/calque"
+	"github.com/calque-ai/go-calque/pkg/middleware/ai"
+	"github.com/calque-ai/go-calque/pkg/middleware/tools"
+)
+
+// mockTool implements tools.Tool for testing
+type mockTool struct {
+	name        string
+	description string
+	schema      *jsonschema.Schema
+}
+
+func (m *mockTool) Name() string {
+	return m.name
+}
+
+func (m *mockTool) Description() string {
+	return m.description
+}
+
+func (m *mockTool) ParametersSchema() *jsonschema.Schema {
+	return m.schema
+}
+
+func (m *mockTool) Execute(_ string) (string, error) {
+	return "mock result", nil
+}
+
+func (m *mockTool) ServeFlow(_ *calque.Request, w *calque.Response) error {
+	_, err := w.Data.Write([]byte("mock result"))
+	return err
+}
+
+func TestNew(t *testing.T) {
+	tests := []struct {
+		name      string
+		model     string
+		config    *Config
+		expectErr bool
+	}{
+		{
+			name:      "empty model",
+			model:     "",
+			expectErr: true,
+		},
+		{
+			name:  "valid model with API key in config",
+			model: "gpt-3.5-turbo",
+			config: &Config{
+				APIKey: "sk-test-key",
+			},
+			expectErr: false,
+		},
+		{
+			name:      "valid model without API key",
+			model:     "gpt-4",
+			expectErr: true, // Should fail if no API key in env or config
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Clear environment variable for clean test
+			oldKey := os.Getenv("OPENAI_API_KEY")
+			os.Unsetenv("OPENAI_API_KEY")
+			defer func() {
+				if oldKey != "" {
+					os.Setenv("OPENAI_API_KEY", oldKey)
+				}
+			}()
+
+			var opts []Option
+			if tt.config != nil {
+				opts = append(opts, WithConfig(tt.config))
+			}
+
+			client, err := New(tt.model, opts...)
+			if tt.expectErr {
+				if err == nil {
+					t.Errorf("expected error but got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+
+			if client == nil {
+				t.Error("expected client but got nil")
+				return
+			}
+
+			if client.model != tt.model {
+				t.Errorf("expected model %s, got %s", tt.model, client.model)
+			}
+		})
+	}
+}
+
+func TestDefaultConfig(t *testing.T) {
+	// Set test environment variable
+	testKey := "sk-test-key"
+	os.Setenv("OPENAI_API_KEY", testKey)
+	defer os.Unsetenv("OPENAI_API_KEY")
+
+	config := DefaultConfig()
+
+	if config.APIKey != testKey {
+		t.Errorf("expected API key %s, got %s", testKey, config.APIKey)
+	}
+
+	if config.Temperature == nil || *config.Temperature != 0.7 {
+		t.Errorf("expected temperature 0.7, got %v", config.Temperature)
+	}
+
+	if config.Stream == nil || !*config.Stream {
+		t.Errorf("expected stream to be true, got %v", config.Stream)
+	}
+}
+
+func TestWithConfig(t *testing.T) {
+	config := &Config{
+		APIKey:              "test-key",
+		Temperature:         ai.Float32Ptr(0.9),
+		MaxCompletionTokens: ai.IntPtr(1000),
+	}
+
+	option := WithConfig(config)
+
+	// This would normally be used in New(), but we can test the option directly
+	testConfig := DefaultConfig()
+	option.Apply(testConfig)
+
+	if testConfig.APIKey != config.APIKey {
+		t.Errorf("expected API key %s, got %s", config.APIKey, testConfig.APIKey)
+	}
+
+	if testConfig.Temperature == nil || *testConfig.Temperature != 0.9 {
+		t.Errorf("expected temperature 0.9, got %v", testConfig.Temperature)
+	}
+
+	if testConfig.MaxCompletionTokens == nil || *testConfig.MaxCompletionTokens != 1000 {
+		t.Errorf("expected max completion tokens 1000, got %v", testConfig.MaxCompletionTokens)
+	}
+}
+
+func TestConvertToOpenAITools(t *testing.T) {
+	// Create a mock tool for testing
+	mockTool := &mockTool{
+		name:        "test_tool",
+		description: "A test tool",
+		schema: &jsonschema.Schema{
+			Type:     "object",
+			Required: []string{"input"},
+		},
+	}
+
+	client := &Client{
+		model:  "gpt-3.5-turbo",
+		config: DefaultConfig(),
+	}
+
+	openaiTools := client.convertToOpenAITools([]tools.Tool{mockTool})
+
+	if len(openaiTools) != 1 {
+		t.Errorf("expected 1 tool, got %d", len(openaiTools))
+		return
+	}
+
+	tool := openaiTools[0]
+	if tool.Function.Name != "test_tool" {
+		t.Errorf("expected tool name 'test_tool', got '%s'", tool.Function.Name)
+	}
+
+	if tool.Function.Description != "A test tool" {
+		t.Errorf("expected tool description 'A test tool', got '%s'", tool.Function.Description)
+	}
+}
+
+// Integration test that requires a real API key
+func TestChatIntegration(t *testing.T) {
+	apiKey := os.Getenv("OPENAI_API_KEY")
+	if apiKey == "" {
+		t.Skip("OPENAI_API_KEY not set, skipping integration test")
+	}
+
+	client, err := New("gpt-3.5-turbo")
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	// Create a simple request
+	req := &calque.Request{
+		Context: context.Background(),
+		Data:    strings.NewReader("Hello, how are you?"),
+	}
+
+	// Create a response buffer
+	var buf strings.Builder
+	resp := &calque.Response{
+		Data: &buf,
+	}
+
+	// Test simple chat
+	err = client.Chat(req, resp, nil)
+	if err != nil {
+		t.Fatalf("chat failed: %v", err)
+	}
+
+	if buf.Len() == 0 {
+		t.Error("expected response content but got empty")
+	}
+}
+
+// TestInputToMessages tests the conversion of classified input to OpenAI message format
+func TestInputToMessages(t *testing.T) {
+	client := &Client{
+		model:  "gpt-3.5-turbo",
+		config: DefaultConfig(),
+	}
+
+	tests := []struct {
+		name        string
+		input       *ai.ClassifiedInput
+		expectError bool
+		checkFunc   func([]openai.ChatCompletionMessage) error
+	}{
+		{
+			name: "text input",
+			input: &ai.ClassifiedInput{
+				Type: ai.TextInput,
+				Text: "Hello, world!",
+			},
+			checkFunc: func(messages []openai.ChatCompletionMessage) error {
+				if len(messages) != 1 {
+					return fmt.Errorf("expected 1 message, got %d", len(messages))
+				}
+				if messages[0].Role != openai.ChatMessageRoleUser {
+					return fmt.Errorf("expected user role, got %s", messages[0].Role)
+				}
+				if messages[0].Content != "Hello, world!" {
+					return fmt.Errorf("expected 'Hello, world!', got %s", messages[0].Content)
+				}
+				return nil
+			},
+		},
+		{
+			name: "multimodal input with text and image",
+			input: &ai.ClassifiedInput{
+				Type: ai.MultimodalJSONInput,
+				Multimodal: &ai.MultimodalInput{
+					Parts: []ai.ContentPart{
+						{Type: "text", Text: "What's in this image?"},
+						{Type: "image", Data: []byte("fake-image-data"), MimeType: "image/jpeg"},
+					},
+				},
+			},
+			checkFunc: func(messages []openai.ChatCompletionMessage) error {
+				if len(messages) != 1 {
+					return fmt.Errorf("expected 1 message, got %d", len(messages))
+				}
+				if len(messages[0].MultiContent) != 2 {
+					return fmt.Errorf("expected 2 content parts, got %d", len(messages[0].MultiContent))
+				}
+				if messages[0].MultiContent[0].Type != openai.ChatMessagePartTypeText {
+					return fmt.Errorf("expected text part, got %s", messages[0].MultiContent[0].Type)
+				}
+				if messages[0].MultiContent[1].Type != openai.ChatMessagePartTypeImageURL {
+					return fmt.Errorf("expected image URL part, got %s", messages[0].MultiContent[1].Type)
+				}
+				return nil
+			},
+		},
+		{
+			name: "unsupported input type",
+			input: &ai.ClassifiedInput{
+				Type: ai.InputType(999),
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			messages, err := client.inputToMessages(tt.input)
+
+			if tt.expectError {
+				if err == nil {
+					t.Error("Expected error, got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("inputToMessages() error = %v", err)
+				return
+			}
+
+			if tt.checkFunc != nil {
+				if err := tt.checkFunc(messages); err != nil {
+					t.Errorf("inputToMessages() %v", err)
+				}
+			}
+		})
+	}
+}
+
+// TestApplyChatConfig tests the application of configuration to chat requests
+func TestApplyChatConfig(t *testing.T) {
+	tests := []struct {
+		name   string
+		config *Config
+		schema *ai.ResponseFormat
+		check  func(*openai.ChatCompletionRequest) error
+	}{
+		{
+			name: "basic config",
+			config: &Config{
+				Temperature:         ai.Float32Ptr(0.8),
+				TopP:                ai.Float32Ptr(0.9),
+				MaxCompletionTokens: ai.IntPtr(1500),
+				N:                   ai.IntPtr(2),
+				Stop:                []string{"END", "STOP"},
+				PresencePenalty:     ai.Float32Ptr(0.5),
+				FrequencyPenalty:    ai.Float32Ptr(0.3),
+				User:                "test-user",
+				Seed:                ai.IntPtr(42),
+			},
+			check: func(req *openai.ChatCompletionRequest) error {
+				if req.Temperature != 0.8 {
+					return fmt.Errorf("temperature = %v, want 0.8", req.Temperature)
+				}
+				if req.TopP != 0.9 {
+					return fmt.Errorf("topP = %v, want 0.9", req.TopP)
+				}
+				if req.MaxCompletionTokens != 1500 {
+					return fmt.Errorf("maxCompletionTokens = %v, want 1500", req.MaxCompletionTokens)
+				}
+				if req.N != 2 {
+					return fmt.Errorf("n = %v, want 2", req.N)
+				}
+				if len(req.Stop) != 2 {
+					return fmt.Errorf("stop length = %v, want 2", len(req.Stop))
+				}
+				if req.PresencePenalty != 0.5 {
+					return fmt.Errorf("presencePenalty = %v, want 0.5", req.PresencePenalty)
+				}
+				if req.FrequencyPenalty != 0.3 {
+					return fmt.Errorf("frequencyPenalty = %v, want 0.3", req.FrequencyPenalty)
+				}
+				if req.User != "test-user" {
+					return fmt.Errorf("user = %v, want test-user", req.User)
+				}
+				if req.Seed == nil || *req.Seed != 42 {
+					return fmt.Errorf("seed = %v, want 42", req.Seed)
+				}
+				return nil
+			},
+		},
+		{
+			name: "json_object schema",
+			config: &Config{
+				ResponseFormat: &ai.ResponseFormat{
+					Type: "json_object",
+				},
+			},
+			check: func(req *openai.ChatCompletionRequest) error {
+				if req.ResponseFormat == nil {
+					return fmt.Errorf("responseFormat should be set")
+				}
+				if req.ResponseFormat.Type != openai.ChatCompletionResponseFormatTypeJSONObject {
+					return fmt.Errorf("responseFormat type = %v, want json_object", req.ResponseFormat.Type)
+				}
+				return nil
+			},
+		},
+		{
+			name: "json_schema with schema override",
+			config: &Config{
+				ResponseFormat: &ai.ResponseFormat{
+					Type: "json_object",
+				},
+			},
+			schema: &ai.ResponseFormat{
+				Type: "json_schema",
+				Schema: &jsonschema.Schema{
+					Type:       "object",
+					Properties: orderedmap.New[string, *jsonschema.Schema](),
+				},
+			},
+			check: func(req *openai.ChatCompletionRequest) error {
+				if req.ResponseFormat == nil {
+					return fmt.Errorf("responseFormat should be set")
+				}
+				if req.ResponseFormat.Type != openai.ChatCompletionResponseFormatTypeJSONSchema {
+					return fmt.Errorf("responseFormat type = %v, want json_schema", req.ResponseFormat.Type)
+				}
+				if req.ResponseFormat.JSONSchema == nil {
+					return fmt.Errorf("JSONSchema should be set")
+				}
+				return nil
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &Client{
+				model:  "gpt-3.5-turbo",
+				config: tt.config,
+			}
+
+			req := &openai.ChatCompletionRequest{
+				Model: client.model,
+			}
+
+			client.applyChatConfig(req, tt.schema)
+
+			if tt.check != nil {
+				if err := tt.check(req); err != nil {
+					t.Errorf("applyChatConfig() %v", err)
+				}
+			}
+		})
+	}
+}
+
+// TestBuildRequestConfig tests the request configuration building
+func TestBuildRequestConfig(t *testing.T) {
+	client := &Client{
+		model: "gpt-3.5-turbo",
+		config: &Config{
+			Temperature:         ai.Float32Ptr(0.7),
+			MaxCompletionTokens: ai.IntPtr(100),
+		},
+	}
+
+	tests := []struct {
+		name        string
+		input       *ai.ClassifiedInput
+		schema      *ai.ResponseFormat
+		tools       []tools.Tool
+		expectError bool
+		checkFunc   func(*RequestConfig) error
+	}{
+		{
+			name: "text input with tools",
+			input: &ai.ClassifiedInput{
+				Type: ai.TextInput,
+				Text: "Hello",
+			},
+			tools: []tools.Tool{
+				&mockTool{
+					name:        "test_tool",
+					description: "A test tool",
+					schema: &jsonschema.Schema{
+						Type: "object",
+						Properties: func() *orderedmap.OrderedMap[string, *jsonschema.Schema] {
+							props := orderedmap.New[string, *jsonschema.Schema]()
+							props.Set("input", &jsonschema.Schema{Type: "string"})
+							return props
+						}(),
+						Required: []string{"input"},
+					},
+				},
+			},
+			checkFunc: func(config *RequestConfig) error {
+				if len(config.ChatRequest.Tools) != 1 {
+					return fmt.Errorf("expected 1 tool, got %d", len(config.ChatRequest.Tools))
+				}
+				if config.ChatRequest.ToolChoice != "auto" {
+					return fmt.Errorf("expected tool choice 'auto', got %v", config.ChatRequest.ToolChoice)
+				}
+				return nil
+			},
+		},
+		{
+			name: "text input with schema",
+			input: &ai.ClassifiedInput{
+				Type: ai.TextInput,
+				Text: "Generate JSON",
+			},
+			schema: &ai.ResponseFormat{
+				Type: "json_object",
+			},
+			checkFunc: func(config *RequestConfig) error {
+				if config.ChatRequest.ResponseFormat == nil {
+					return fmt.Errorf("responseFormat should be set")
+				}
+				return nil
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config, err := client.buildRequestConfig(tt.input, tt.schema, tt.tools)
+
+			if tt.expectError {
+				if err == nil {
+					t.Error("Expected error, got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("buildRequestConfig() error = %v", err)
+				return
+			}
+
+			if tt.checkFunc != nil {
+				if err := tt.checkFunc(config); err != nil {
+					t.Errorf("buildRequestConfig() %v", err)
+				}
+			}
+		})
+	}
+}
+
+// TestMultimodalToMessages tests multimodal input conversion
+func TestMultimodalToMessages(t *testing.T) {
+	client := &Client{
+		model:  "gpt-4-vision-preview",
+		config: DefaultConfig(),
+	}
+
+	tests := []struct {
+		name        string
+		multimodal  *ai.MultimodalInput
+		expectError bool
+		checkFunc   func([]openai.ChatCompletionMessage) error
+	}{
+		{
+			name:        "nil multimodal input",
+			multimodal:  nil,
+			expectError: true,
+		},
+		{
+			name: "text only",
+			multimodal: &ai.MultimodalInput{
+				Parts: []ai.ContentPart{
+					{Type: "text", Text: "Hello world"},
+				},
+			},
+			checkFunc: func(messages []openai.ChatCompletionMessage) error {
+				if len(messages) != 1 {
+					return fmt.Errorf("expected 1 message, got %d", len(messages))
+				}
+				if len(messages[0].MultiContent) != 1 {
+					return fmt.Errorf("expected 1 content part, got %d", len(messages[0].MultiContent))
+				}
+				if messages[0].MultiContent[0].Type != openai.ChatMessagePartTypeText {
+					return fmt.Errorf("expected text part")
+				}
+				return nil
+			},
+		},
+		{
+			name: "image with data",
+			multimodal: &ai.MultimodalInput{
+				Parts: []ai.ContentPart{
+					{Type: "image", Data: []byte("test-image-data"), MimeType: "image/png"},
+				},
+			},
+			checkFunc: func(messages []openai.ChatCompletionMessage) error {
+				if len(messages[0].MultiContent) != 1 {
+					return fmt.Errorf("expected 1 content part, got %d", len(messages[0].MultiContent))
+				}
+				if messages[0].MultiContent[0].Type != openai.ChatMessagePartTypeImageURL {
+					return fmt.Errorf("expected image URL part")
+				}
+				if messages[0].MultiContent[0].ImageURL == nil {
+					return fmt.Errorf("image URL should not be nil")
+				}
+				return nil
+			},
+		},
+		{
+			name: "image with reader",
+			multimodal: &ai.MultimodalInput{
+				Parts: []ai.ContentPart{
+					{Type: "image", Reader: bytes.NewReader([]byte("test-image-data")), MimeType: "image/jpeg"},
+				},
+			},
+			checkFunc: func(messages []openai.ChatCompletionMessage) error {
+				if len(messages[0].MultiContent) != 1 {
+					return fmt.Errorf("expected 1 content part, got %d", len(messages[0].MultiContent))
+				}
+				if messages[0].MultiContent[0].Type != openai.ChatMessagePartTypeImageURL {
+					return fmt.Errorf("expected image URL part")
+				}
+				return nil
+			},
+		},
+		{
+			name: "unsupported audio",
+			multimodal: &ai.MultimodalInput{
+				Parts: []ai.ContentPart{
+					{Type: "audio", Data: []byte("audio-data"), MimeType: "audio/wav"},
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "unsupported video",
+			multimodal: &ai.MultimodalInput{
+				Parts: []ai.ContentPart{
+					{Type: "video", Data: []byte("video-data"), MimeType: "video/mp4"},
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "empty parts",
+			multimodal: &ai.MultimodalInput{
+				Parts: []ai.ContentPart{},
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			messages, err := client.multimodalToMessages(tt.multimodal)
+
+			if tt.expectError {
+				if err == nil {
+					t.Error("Expected error, got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("multimodalToMessages() error = %v", err)
+				return
+			}
+
+			if tt.checkFunc != nil {
+				if err := tt.checkFunc(messages); err != nil {
+					t.Errorf("multimodalToMessages() %v", err)
+				}
+			}
+		})
+	}
+}
+
+// TestEnhancedConvertToOpenAITools tests tool conversion with more scenarios
+func TestEnhancedConvertToOpenAITools(t *testing.T) {
+	client := &Client{
+		model:  "gpt-3.5-turbo",
+		config: DefaultConfig(),
+	}
+
+	tests := []struct {
+		name      string
+		tools     []tools.Tool
+		checkFunc func([]openai.Tool) error
+	}{
+		{
+			name:  "empty tools",
+			tools: []tools.Tool{},
+			checkFunc: func(tools []openai.Tool) error {
+				if len(tools) != 0 {
+					return fmt.Errorf("expected 0 tools, got %d", len(tools))
+				}
+				return nil
+			},
+		},
+		{
+			name: "single tool",
+			tools: []tools.Tool{
+				&mockTool{
+					name:        "calculator",
+					description: "Performs calculations",
+					schema: &jsonschema.Schema{
+						Type: "object",
+						Properties: func() *orderedmap.OrderedMap[string, *jsonschema.Schema] {
+							props := orderedmap.New[string, *jsonschema.Schema]()
+							props.Set("expression", &jsonschema.Schema{Type: "string", Description: "Mathematical expression"})
+							return props
+						}(),
+						Required: []string{"expression"},
+					},
+				},
+			},
+			checkFunc: func(tools []openai.Tool) error {
+				if len(tools) != 1 {
+					return fmt.Errorf("expected 1 tool, got %d", len(tools))
+				}
+				tool := tools[0]
+				if tool.Type != openai.ToolTypeFunction {
+					return fmt.Errorf("expected function tool type")
+				}
+				if tool.Function.Name != "calculator" {
+					return fmt.Errorf("expected calculator name, got %s", tool.Function.Name)
+				}
+				if tool.Function.Description != "Performs calculations" {
+					return fmt.Errorf("expected description 'Performs calculations', got %s", tool.Function.Description)
+				}
+				return nil
+			},
+		},
+		{
+			name: "multiple tools",
+			tools: []tools.Tool{
+				&mockTool{
+					name:        "tool1",
+					description: "First tool",
+					schema:      &jsonschema.Schema{Type: "object"},
+				},
+				&mockTool{
+					name:        "tool2",
+					description: "Second tool",
+					schema:      &jsonschema.Schema{Type: "object"},
+				},
+			},
+			checkFunc: func(tools []openai.Tool) error {
+				if len(tools) != 2 {
+					return fmt.Errorf("expected 2 tools, got %d", len(tools))
+				}
+				return nil
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			openaiTools := client.convertToOpenAITools(tt.tools)
+
+			if tt.checkFunc != nil {
+				if err := tt.checkFunc(openaiTools); err != nil {
+					t.Errorf("convertToOpenAITools() %v", err)
+				}
+			}
+		})
+	}
+}
+
+// TestWriteOpenAIToolCalls tests tool call formatting
+func TestWriteOpenAIToolCalls(t *testing.T) {
+	client := &Client{
+		model:  "gpt-3.5-turbo",
+		config: DefaultConfig(),
+	}
+
+	tests := []struct {
+		name      string
+		toolCalls []openai.ToolCall
+		checkFunc func(string) error
+	}{
+		{
+			name: "single tool call",
+			toolCalls: []openai.ToolCall{
+				{
+					Type: "function",
+					Function: openai.FunctionCall{
+						Name:      "calculator",
+						Arguments: `{"expression":"2+2"}`,
+					},
+				},
+			},
+			checkFunc: func(output string) error {
+				var result map[string]interface{}
+				if err := json.Unmarshal([]byte(output), &result); err != nil {
+					return fmt.Errorf("failed to parse JSON: %v", err)
+				}
+				toolCalls, ok := result["tool_calls"]
+				if !ok {
+					return fmt.Errorf("missing tool_calls field")
+				}
+				calls := toolCalls.([]interface{})
+				if len(calls) != 1 {
+					return fmt.Errorf("expected 1 tool call, got %d", len(calls))
+				}
+				return nil
+			},
+		},
+		{
+			name: "multiple tool calls",
+			toolCalls: []openai.ToolCall{
+				{
+					Type: "function",
+					Function: openai.FunctionCall{
+						Name:      "tool1",
+						Arguments: `{"input":"test1"}`,
+					},
+				},
+				{
+					Type: "function",
+					Function: openai.FunctionCall{
+						Name:      "tool2",
+						Arguments: `{"input":"test2"}`,
+					},
+				},
+			},
+			checkFunc: func(output string) error {
+				var result map[string]interface{}
+				if err := json.Unmarshal([]byte(output), &result); err != nil {
+					return fmt.Errorf("failed to parse JSON: %v", err)
+				}
+				toolCalls, ok := result["tool_calls"]
+				if !ok {
+					return fmt.Errorf("missing tool_calls field")
+				}
+				calls := toolCalls.([]interface{})
+				if len(calls) != 2 {
+					return fmt.Errorf("expected 2 tool calls, got %d", len(calls))
+				}
+				return nil
+			},
+		},
+		{
+			name:      "empty tool calls",
+			toolCalls: []openai.ToolCall{},
+			checkFunc: func(output string) error {
+				var result map[string]interface{}
+				if err := json.Unmarshal([]byte(output), &result); err != nil {
+					return fmt.Errorf("failed to parse JSON: %v", err)
+				}
+				toolCalls, ok := result["tool_calls"]
+				if !ok {
+					return fmt.Errorf("missing tool_calls field")
+				}
+				if toolCalls == nil {
+					return nil // Empty tool calls are represented as null/nil
+				}
+				calls, ok := toolCalls.([]interface{})
+				if !ok {
+					return fmt.Errorf("tool_calls is not an array: %T", toolCalls)
+				}
+				if len(calls) != 0 {
+					return fmt.Errorf("expected 0 tool calls, got %d", len(calls))
+				}
+				return nil
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf strings.Builder
+			resp := &calque.Response{
+				Data: &buf,
+			}
+
+			err := client.writeOpenAIToolCalls(tt.toolCalls, resp)
+			if err != nil {
+				t.Errorf("writeOpenAIToolCalls() error = %v", err)
+				return
+			}
+
+			if tt.checkFunc != nil {
+				if err := tt.checkFunc(buf.String()); err != nil {
+					t.Errorf("writeOpenAIToolCalls() %v", err)
+				}
+			}
+		})
+	}
+}
+
+// Mock HTTP server for integration testing
+func createMockOpenAIServer(t *testing.T, responses map[string]string) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1/chat/completions" {
+			handleChatCompletionRequest(t, w, r, responses)
+		} else {
+			http.Error(w, "Not found", 404)
+		}
+	}))
+}
+
+// handleChatCompletionRequest handles the chat completion request in the mock server
+func handleChatCompletionRequest(t *testing.T, w http.ResponseWriter, r *http.Request, responses map[string]string) {
+	// Parse request
+	var req openai.ChatCompletionRequest
+	body, _ := io.ReadAll(r.Body)
+	if err := json.Unmarshal(body, &req); err != nil {
+		t.Errorf("Failed to decode request: %v", err)
+		http.Error(w, "Bad request", 400)
+		return
+	}
+
+	// Get response based on message content
+	responseContent := getResponseContent(req, responses)
+
+	// Check if streaming is requested
+	if req.Stream {
+		sendStreamingResponse(w, responseContent)
+	} else {
+		sendNonStreamingResponse(w, responseContent)
+	}
+}
+
+// getResponseContent extracts the appropriate response content based on the request
+func getResponseContent(req openai.ChatCompletionRequest, responses map[string]string) string {
+	if len(req.Messages) > 0 && req.Messages[0].Content != "" {
+		if content, exists := responses[req.Messages[0].Content]; exists {
+			return content
+		}
+	}
+	return "Mock response"
+}
+
+// sendStreamingResponse sends a streaming response
+func sendStreamingResponse(w http.ResponseWriter, content string) {
+	w.Header().Set("Content-Type", "text/event-stream")
+	response := openai.ChatCompletionStreamResponse{
+		Choices: []openai.ChatCompletionStreamChoice{
+			{
+				Delta: openai.ChatCompletionStreamChoiceDelta{
+					Content: content,
+				},
+			},
+		},
+	}
+	data, _ := json.Marshal(response)
+	fmt.Fprintf(w, "data: %s\n\n", data)
+	fmt.Fprintf(w, "data: [DONE]\n\n")
+}
+
+// sendNonStreamingResponse sends a non-streaming response
+func sendNonStreamingResponse(w http.ResponseWriter, content string) {
+	w.Header().Set("Content-Type", "application/json")
+	response := openai.ChatCompletionResponse{
+		Choices: []openai.ChatCompletionChoice{
+			{
+				Message: openai.ChatCompletionMessage{
+					Role:    openai.ChatMessageRoleAssistant,
+					Content: content,
+				},
+			},
+		},
+	}
+	json.NewEncoder(w).Encode(response)
+}
+
+// TestChatWithMockServer tests the Chat method with a mock server
+func TestChatWithMockServer(t *testing.T) {
+	// Create mock server
+	responses := map[string]string{
+		"Hello":        "Hi there!",
+		"What is 2+2?": "The answer is 4.",
+	}
+	server := createMockOpenAIServer(t, responses)
+	defer server.Close()
+
+	// Create client with mock server
+	config := &Config{
+		APIKey:  "test-key",
+		BaseURL: server.URL + "/v1",
+		Stream:  ai.BoolPtr(false), // Test non-streaming first
+	}
+	client, err := New("gpt-3.5-turbo", WithConfig(config))
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "simple greeting",
+			input:    "Hello",
+			expected: "Hi there!",
+		},
+		{
+			name:     "math question",
+			input:    "What is 2+2?",
+			expected: "The answer is 4.",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reader := strings.NewReader(tt.input)
+			req := calque.NewRequest(context.Background(), reader)
+
+			var response strings.Builder
+			res := calque.NewResponse(&response)
+
+			err := client.Chat(req, res, nil)
+			if err != nil {
+				t.Errorf("Chat() error = %v", err)
+				return
+			}
+
+			result := response.String()
+			if result != tt.expected {
+				t.Errorf("Chat() = %q, want %q", result, tt.expected)
+			}
+		})
+	}
+}
+
+// TestErrorHandling tests various error scenarios
+func TestErrorHandling(t *testing.T) {
+	tests := []struct {
+		name          string
+		setupClient   func() *Client
+		input         string
+		expectError   bool
+		errorContains string
+	}{
+		{
+			name: "nil multimodal input",
+			setupClient: func() *Client {
+				return &Client{
+					model:  "gpt-4",
+					config: DefaultConfig(),
+				}
+			},
+			input:         "", // Will be ignored since we're testing multimodal
+			expectError:   true,
+			errorContains: "multimodal input cannot be nil",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := tt.setupClient()
+
+			if tt.name == "nil multimodal input" {
+				_, err := client.multimodalToMessages(nil)
+				if !tt.expectError {
+					t.Errorf("Expected no error, got: %v", err)
+					return
+				}
+				if err == nil {
+					t.Error("Expected error, got none")
+					return
+				}
+				if !strings.Contains(err.Error(), tt.errorContains) {
+					t.Errorf("Expected error to contain %q, got: %v", tt.errorContains, err)
+				}
+			}
+		})
+	}
+}
+
+// TestIsGPT5Model tests the GPT-5 model detection
+func TestIsGPT5Model(t *testing.T) {
+	tests := []struct {
+		model    string
+		expected bool
+	}{
+		{"gpt-5", true},
+		{"gpt-5o", true},
+		{"gpt-5o-mini", true},
+		{"gpt-4", false},
+		{"gpt-4o", false},
+		{"gpt-3.5-turbo", false},
+		{"gpt-4o-mini", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.model, func(t *testing.T) {
+			client := &Client{model: tt.model}
+			result := client.isGPT5Model()
+			if result != tt.expected {
+				t.Errorf("isGPT5Model() for %s = %v, want %v", tt.model, result, tt.expected)
+			}
+		})
+	}
+}
+
+// TestGPT5Configuration tests that GPT-5 models handle beta limitations correctly
+func TestGPT5Configuration(t *testing.T) {
+	client := &Client{
+		model: "gpt-5",
+		config: &Config{
+			Temperature:         ai.Float32Ptr(0.8),
+			TopP:                ai.Float32Ptr(0.9),
+			MaxCompletionTokens: ai.IntPtr(1000),
+			N:                   ai.IntPtr(2),
+			PresencePenalty:     ai.Float32Ptr(0.1),
+			FrequencyPenalty:    ai.Float32Ptr(0.1),
+		},
+	}
+
+	req := &openai.ChatCompletionRequest{
+		Model: "gpt-5",
+		Messages: []openai.ChatCompletionMessage{
+			{Role: openai.ChatMessageRoleUser, Content: "Hello"},
+		},
+	}
+
+	client.applyChatConfig(req, nil)
+
+	// GPT-5 should not have these parameters set due to beta limitations
+	if req.Temperature != 0 {
+		t.Errorf("expected temperature to be 0 for GPT-5, got %f", req.Temperature)
+	}
+	if req.TopP != 0 {
+		t.Errorf("expected top_p to be 0 for GPT-5, got %f", req.TopP)
+	}
+	if req.N != 0 {
+		t.Errorf("expected n to be 0 for GPT-5, got %d", req.N)
+	}
+	if req.PresencePenalty != 0 {
+		t.Errorf("expected presence_penalty to be 0 for GPT-5, got %f", req.PresencePenalty)
+	}
+	if req.FrequencyPenalty != 0 {
+		t.Errorf("expected frequency_penalty to be 0 for GPT-5, got %f", req.FrequencyPenalty)
+	}
+
+	// MaxCompletionTokens should still be set
+	if req.MaxCompletionTokens != 1000 {
+		t.Errorf("expected MaxCompletionTokens to be 1000, got %d", req.MaxCompletionTokens)
+	}
+}
+
+// TestConvertToOpenAIToolsOutputFormat tests that the output format matches OpenAI's expected structure


### PR DESCRIPTION
Issue: https://github.com/calque-ai/go-calque/issues/8
- added OpenAI Integration: Added full ai.Client implementation with streaming, tool calling, multimodal support, and JSON schema validation
- added config options (temperature, max tokens, penalties, etc.) and API key management via environment variables
- documentation update, example and unit test added