### PR TITLE
fix: leaks in flow and rate limit

### DIFF
--- a/pkg/calque/converter.go
+++ b/pkg/calque/converter.go
@@ -41,7 +41,7 @@ func (f *Flow) inputToReader(input any) (io.Reader, error) {
 	case io.Reader:
 		return v, nil
 	default:
-		return nil, NewErr(context.Background(), fmt.Sprintf("unsupported input type: %T", input))
+		return nil, NewErr(context.TODO(), fmt.Sprintf("unsupported input type: %T", input))
 	}
 }
 
@@ -100,7 +100,7 @@ func (f *Flow) readerToOutput(reader io.Reader, output any) error {
 		return nil
 
 	default:
-		return NewErr(context.Background(), fmt.Sprintf("unsupported output type: %T (use a converter for custom types)", output))
+		return NewErr(context.TODO(), fmt.Sprintf("unsupported output type: %T (use a converter for custom types)", output))
 	}
 }
 

--- a/pkg/calque/handler.go
+++ b/pkg/calque/handler.go
@@ -220,7 +220,7 @@ func Read[T string | []byte](req *Request, outPtr *T) error {
 	case *[]byte:
 		*ptr = buf.Bytes()
 	default:
-		return NewErr(context.Background(), fmt.Sprintf("unsupported type %T", outPtr))
+		return NewErr(req.Context, fmt.Sprintf("unsupported type %T", outPtr))
 	}
 	return nil
 }

--- a/pkg/middleware/ctrl/ratelimit_test.go
+++ b/pkg/middleware/ctrl/ratelimit_test.go
@@ -158,8 +158,8 @@ func TestRateLimiterRefill(t *testing.T) {
 		t.Errorf("Expected %d tokens, got %d", expectedTokens, limiter.tokens)
 	}
 
-	if limiter.lastRefill.Before(now) {
-		t.Error("lastRefill should be updated to recent time")
+	if limiter.lastRefill.Before(now.Add(-100 * time.Millisecond)) {
+		t.Error("lastRefill should be updated to account for added tokens")
 	}
 }
 


### PR DESCRIPTION
- When a flow failed or was cancelled,a background tasks is stuck forever waiting for data that would never come. This is Fixed by making sure all data pipes are properly closed when the flow ends.
- The rate limiter was busy-waiting and losing track of time between token refills. 
- simple context loss